### PR TITLE
Diasble the modebar

### DIFF
--- a/static/js/graphs.js
+++ b/static/js/graphs.js
@@ -192,7 +192,7 @@ function analyze() {
         hovermode: 'closest',
     };
     Plotly.newPlot('chart', data, layout, {
-        showLink: false
+        displayModeBar: false
     });
 }
 


### PR DESCRIPTION
There doesn't seem to be a straightforward way to disable the mode bar or move it to another part of the chart. Disabling removes some non-critical functionality such as downloading images. Zooming in and out can still be achieved by dragging the selected area then double clicking out.
